### PR TITLE
Fix computing threshold for when VAT starts applying

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,9 +110,8 @@
                 </div>
 
                 <div class="explanation">
-                    Your <span class="result-taxrate">8</span>% VAT is
-                    <strong class="result-vat">0.00</strong> which is below the
-                    5.00 limit.
+                    Your total value of goods (price + shipping) <strong class="result-worth">0.00</strong>
+                    does not exceed <strong class="result-limit">0.00</strong> limit.
                 </div>
             </div>
 
@@ -123,8 +122,8 @@
                 </div>
 
                 <div class="explanation">
-                    Your <span class="result-taxrate">8</span>% VAT is
-                    <strong class="result-vat">0.00</strong>.
+                    Your <span class="result-taxrate">8</span>% VAT on value of
+                    goods (price + shipping) is <strong class="result-vat">0.00</strong>.
                 </div>
 
                 <div class="details">

--- a/js/math.js
+++ b/js/math.js
@@ -120,10 +120,12 @@ function parametersByForm(form) {
             fee: 16.00,
             storage: 233.50,
             taxrate: 0.08,
-            vat: 21.00,
+            vatOnWorth: 18.70
             duty: 29.00,
+            vatOnDuty: 2.30,
             costs: 50.00,
             total: 283.50,
+            limit: 63.00,
             hasToPay: true,
         }
 
@@ -140,10 +142,19 @@ function calculateDuties(parameters) {
 
     r.worth = _(r.price + r.shipping);
     r.duty = _(r.fee + r.storage);
-    r.vat = _((r.worth + r.duty) * r.taxrate);
-    r.costs = _(r.vat + r.duty);
-    r.total = _(r.worth + r.costs);
-    r.hasToPay = r.vat >= 5.0;
+    r.vatOnWorth = _(r.worth * r.taxrate);
+    r.vatOnDuty = _(r.duty * r.taxrate);
+    r.totalDuty = r.duty + r.vatOnDuty
+    r.costs = r.vatOnWorth + r.totalDuty;
+    r.total = r.worth + r.costs;
+
+    // Per https://www.post.ch/en/business-solutions/exports-imports-and-customs-clearance/imports/faqs-about-imports-customs-and-vat,
+    // consignments are exempt from duties if the goods do not exceed 65 CHF for
+    // products with VAT 7.7% and 200 CHF for products with VAT 2.5%. These
+    // limits are basically rounded up values for the resulting VAT being below
+    // 5 CHF.
+    r.limit = Math.ceil(5.0 / r.taxrate);
+    r.hasToPay = r.worth > r.limit;
 
     return r;
 }

--- a/js/math.js
+++ b/js/math.js
@@ -120,11 +120,10 @@ function parametersByForm(form) {
             fee: 16.00,
             storage: 233.50,
             taxrate: 0.08,
-            vat: 21.55,
-            expenses: 13.00,
-            duty: 36.00,
-            costs: 57.55,
-            total: 291.05,
+            vat: 21.00,
+            duty: 29.00,
+            costs: 50.00,
+            total: 283.50,
             hasToPay: true,
         }
 

--- a/js/tests.js
+++ b/js/tests.js
@@ -118,11 +118,92 @@ function testPostfinanceFormula() {
     assert (result.taxrate == 0.08, "taxrate");
     assert (result.worth == 233.50, "worth");
 
-    assert (result.vat == 21.00, "vat");
+    assert (result.vatOnWorth == 18.70, "vat on worth");
     assert (result.duty == 29.00, "duty");
+    assert (result.vatOnDuty == 2.30, "vat on duty");
     assert (result.costs == 50.00, "total taxes");
     assert (result.total == 283.50, "total costs");
+    assert (result.limit == 63.00, "limit");
+    assert (result.hasToPay, "has to pay");
 }
 
+function testWorthBelowLimitForVat7_7() {
+    var result = calculateDuties({
+        price: 50,
+        shipping: 0,
+        fee: 16,
+        storage: 13,
+        taxrate: 0.077
+    });
+
+    assert (result.limit == 65.00, "limit");
+    assert (!result.hasToPay, "has to pay");
+}
+
+function testWorthAtLimitForVat7_7() {
+    var result = calculateDuties({
+        price: 65,
+        shipping: 0,
+        fee: 16,
+        storage: 13,
+        taxrate: 0.077
+    });
+
+    assert (result.limit == 65.00, "limit");
+    assert (!result.hasToPay, "has to pay");
+}
+
+
+function testWorthJustAboveLimitForVat7_7() {
+    var result = calculateDuties({
+        price: 65.06,
+        shipping: 0,
+        fee: 16,
+        storage: 13,
+        taxrate: 0.077
+    });
+
+    assert (result.limit == 65.00, "limit");
+    assert (result.hasToPay, "has to pay");
+}
+
+function testWorthBelowLimitForVat2_5() {
+    var result = calculateDuties({
+        price: 150,
+        shipping: 0,
+        fee: 16,
+        storage: 13,
+        taxrate: 0.025
+    });
+
+    assert (result.limit == 200.00, "limit");
+    assert (!result.hasToPay, "has to pay");
+}
+
+function testWorthAtLimitForVat2_5() {
+    var result = calculateDuties({
+        price: 200,
+        shipping: 0,
+        fee: 16,
+        storage: 13,
+        taxrate: 0.025
+    });
+
+    assert (result.limit == 200.00, "limit");
+    assert (!result.hasToPay, "has to pay");
+}
+
+function testWorthJustAboveLimitForVat2_5() {
+    var result = calculateDuties({
+        price: 200.05,
+        shipping: 0,
+        fee: 16,
+        storage: 13,
+        taxrate: 0.025
+    });
+
+    assert (result.limit == 200.00, "limit");
+    assert (result.hasToPay, "has to pay");
+}
 
 runTests();

--- a/js/tests.js
+++ b/js/tests.js
@@ -27,11 +27,11 @@ function runTests() {
             console.log("Running " + key);
 
             try {
-                window[key]();    
+                window[key]();
             } catch(e) {
                 console.log(e);
             }
-            
+
             count++;
         }
     })
@@ -117,12 +117,11 @@ function testPostfinanceFormula() {
     assert (result.storage == 13.00, "storage");
     assert (result.taxrate == 0.08, "taxrate");
     assert (result.worth == 233.50, "worth");
-    
-    assert (result.vat == 21.55, "vat");
-    assert (result.expenses == 7.00, "expenses");
-    assert (result.duty == 36.00, "duty");
-    assert (result.costs == 57.55, "total taxes");
-    assert (result.total == 291.05, "total costs");
+
+    assert (result.vat == 21.00, "vat");
+    assert (result.duty == 29.00, "duty");
+    assert (result.costs == 50.00, "total taxes");
+    assert (result.total == 283.50, "total costs");
 }
 
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -182,12 +182,20 @@ ready(function() {
             if ((result.price + result.shipping) === 0) {
                 el.innerHTML = '0.00';
             } else {
-                el.innerHTML = result.vat.toFixed(2);
+                el.innerHTML = result.vatOnWorth.toFixed(2);
             }
         });
 
+        eachElement('.result-worth', function(el) {
+            el.innerHTML = result.worth.toFixed(2);
+        });
+
+        eachElement('.result-limit', function(el) {
+            el.innerHTML = result.limit.toFixed(2);
+        });
+
         eachElement('.result-duty', function(el) {
-            el.innerHTML = result.duty.toFixed(2);
+            el.innerHTML = result.totalDuty.toFixed(2);
         });
 
         eachElement('.result-taxrate', function(el) {


### PR DESCRIPTION
As discussed in https://github.com/href/duties/issues/3, we follow the logic described in https://www.post.ch/en/business-solutions/exports-imports-and-customs-clearance/imports/faqs-about-imports-customs-and-vat, i.e. compute the limit for value of goods and compare the value of goods with this limit. Because this approach is not fully compatible with checking whether computed VAT is less than 5 CHF (corner cases are close around the threshold value), we also change the UI to not display confusing messages (e.g. for 64.90 CHF VAT on value of goods would be 5.00 CHF, which is not below 5.00 CHF limit).