### PR TITLE
Add ups courier option

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
                     <span class="label-text">Courier</span>
                     <select name="courier">
                         <option value="dhl">DHL</option>
+                        <option value="ups">UPS</option>
                         <option value="post" selected>Post</option>
                     </select>
                 </label>

--- a/js/math.js
+++ b/js/math.js
@@ -21,11 +21,10 @@ var courierFees = {
 
         return dutyfee + expenses;
     },
-    ups: function(country, price, shipping, taxrate, over1t) {
+    ups: function(country, price) {
         var dutyfee = Math.max(price * 0.03, 25.15);
-        var expenses = dutyfee * taxrate;
 
-        return dutyfee + expenses;
+        return dutyfee;
     }
 }
 

--- a/js/math.js
+++ b/js/math.js
@@ -20,6 +20,12 @@ var courierFees = {
         var expenses = (price + shipping) * taxrate * 0.02;
 
         return dutyfee + expenses;
+    },
+    ups: function(country, price, shipping, taxrate, over1t) {
+        var dutyfee = Math.max(price * 0.03, 25.15);
+        var expenses = dutyfee * taxrate;
+
+        return dutyfee + expenses;
     }
 }
 

--- a/js/math.js
+++ b/js/math.js
@@ -22,7 +22,7 @@ var courierFees = {
         return dutyfee + expenses;
     },
     ups: function(country, price) {
-        var dutyfee = Math.max(price * 0.03, 25.15);
+        var dutyfee = Math.max((price + shipping) * 0.03, 25.15);
 
         return dutyfee;
     }

--- a/js/math.js
+++ b/js/math.js
@@ -21,7 +21,7 @@ var courierFees = {
 
         return dutyfee + expenses;
     },
-    ups: function(country, price) {
+    ups: function(country, price, shipping) {
         var dutyfee = Math.max((price + shipping) * 0.03, 25.15);
 
         return dutyfee;

--- a/js/tests.js
+++ b/js/tests.js
@@ -206,4 +206,41 @@ function testWorthJustAboveLimitForVat2_5() {
     assert (result.hasToPay, "has to pay");
 }
 
+
+function testCourierFeeUpsBelowLimit() {
+    var price = 77.27;
+    var shipping = 0;
+    var expectedFees = 25.15;
+    var result = courierFees["ups"]("any", price, shipping);
+
+    assert(result == expectedFees, "ups courier fees below limit");
+}
+
+function testCourierFeeUpsJustBelowLimit() {
+    var price = 838;
+    var shipping = 0;
+    var expectedFees = 25.15;
+    var result = courierFees["ups"]("any", price, shipping);
+
+    assert(result == expectedFees, "ups courier fees just below limit");
+}
+
+function testCourierFeeUpsJustAboveLimit() {
+    var price = 840;
+    var shipping = 0;
+    var expectedFees = 25.2;
+    var result = courierFees["ups"]("any", price, shipping);
+
+    assert(result == expectedFees, "ups courier fees just above limit");
+}
+
+function testCourierFeeUpsConsiderShipping() {
+    var price = 838;
+    var shipping = 20;
+    var expectedFees = 25.74;
+    var result = courierFees["ups"]("any", price, shipping);
+
+    assert(result == expectedFees, "ups courier fees with shipping");
+}
+
 runTests();


### PR DESCRIPTION
Added UPS option and simple calculation.
I used the `Disbursement Fees` calculation available [here](https://www.ups.com/assets/resources/webcontent/de_DE/additional-service-charge-ch.pdf).

It might be different in other contexts, but this covers my usecase:

Bill from merchant
```
price: 63.-
shipping: 14.27.-
```

Bill from UPS:
```
Government Charges: | CHF6.30
Brokerage Charges: | CHF25.15
VAT: | CHF2.05
```

<img width="814" alt="Screenshot 2025-07-01 at 11 47 28" src="https://github.com/user-attachments/assets/75d70b04-2a60-426d-964d-c416a87d8f89" />


They rounded up the VAT from 6.25 to 6.30 but that's fine, the calculator returns `27.2` which corresponds to service change of `25.15` + vat on duty `25.15 * 0.081 = 2.05`

Hopefully future users can now be aware of UPS outrageous service fees